### PR TITLE
Don't generate sales orders or sales invoices if the order is already completed.

### DIFF
--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -23,7 +23,7 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
     def generate(order)
       bench_start = Time.now
 
-      return if !SpreeAvatax::Shared.taxable_order?(order)
+      return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)
       # run this immediately to ensure that everything matches up before modifying the database

--- a/app/models/spree_avatax/sales_order.rb
+++ b/app/models/spree_avatax/sales_order.rb
@@ -19,7 +19,7 @@ class SpreeAvatax::SalesOrder < ActiveRecord::Base
     def generate(order)
       bench_start = Time.now
 
-      return if !SpreeAvatax::Shared.taxable_order?(order)
+      return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)
       # run this immediately to ensure that everything matches up before modifying the database

--- a/lib/spree_avatax/factories.rb
+++ b/lib/spree_avatax/factories.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
     association :order, factory: :shipped_order
     doc_id { generate(:doc_id) }
     doc_code { order.number }
-    doc_date { order.completed_at.to_date }
+    doc_date { order.completed_at.try(:to_date) || 1.day.ago }
     pre_tax_total { order.line_items.sum(:pre_tax_amount) }
     additional_tax_total { order.line_items.sum(:additional_tax_total) }
   end

--- a/spec/models/spree_avatax/sales_order_spec.rb
+++ b/spec/models/spree_avatax/sales_order_spec.rb
@@ -8,7 +8,7 @@ describe SpreeAvatax::SalesOrder do
     end
 
     let(:order) do
-      create(:shipped_order, {
+      create(:order_with_line_items, {
         line_items_count: 1,
         ship_address: create(:address, {
           address1: "1234 Way",
@@ -257,6 +257,24 @@ describe SpreeAvatax::SalesOrder do
           subject
         }.not_to change { SpreeAvatax::SalesOrder.count }
         expect(order.avatax_sales_orders.count).to eq 0
+      end
+
+      it 'does not call avatax' do
+        SpreeAvatax::Shared.tax_svc.should_receive(:gettax).never
+        subject
+      end
+    end
+
+    context 'when the order is already completed' do
+      let(:order) { create(:completed_order_with_totals) }
+
+      let!(:gettax_stub) { }
+
+      it 'does not create a sales invoice' do
+        expect {
+          subject
+        }.not_to change { SpreeAvatax::SalesInvoice.count }
+        expect(order.avatax_sales_invoice).to eq nil
       end
 
       it 'does not call avatax' do


### PR DESCRIPTION
If an order is already completed, there are still some code paths that
will try to generate a new sales order or sales invoice. We don't really
want that to happen because the order is already paid for (so
recalculating taxes is a wasted effort), and also it
deletes old tax adjustments.