### PR TITLE
Fix short ship index to not be unique

### DIFF
--- a/app/models/spree_avatax/short_ship_return_invoice.rb
+++ b/app/models/spree_avatax/short_ship_return_invoice.rb
@@ -90,7 +90,7 @@ class SpreeAvatax::ShortShipReturnInvoice < ActiveRecord::Base
     end
 
     def gettax_line_params(unit_cancels:, taxed_at:)
-      unit_cancels.map do |unit_cancel|
+      unit_cancels.sort_by(&:id).map do |unit_cancel|
         inventory_unit = unit_cancel.inventory_unit
 
         adjustment = unit_cancel.adjustment

--- a/db/migrate/20150518172627_fix_avatax_short_ship_index.rb
+++ b/db/migrate/20150518172627_fix_avatax_short_ship_index.rb
@@ -1,0 +1,30 @@
+class FixAvataxShortShipIndex < ActiveRecord::Migration
+  def up
+    remove_index(
+      :spree_avatax_short_ship_return_invoice_inventory_units,
+      name: 'index_spree_avatax_short_ships_on_invoice_id',
+    )
+
+    # Was previously set as unique, which was not correct -- A short ship return
+    # invoice may have multiple units associated with it
+    add_index(
+      :spree_avatax_short_ship_return_invoice_inventory_units,
+      :short_ship_return_invoice_id,
+      name: 'index_spree_avatax_short_ships_on_invoice_id',
+    )
+  end
+
+  def down
+    remove_index(
+      :spree_avatax_short_ship_return_invoice_inventory_units,
+      name: 'index_spree_avatax_short_ships_on_invoice_id',
+    )
+
+    add_index(
+      :spree_avatax_short_ship_return_invoice_inventory_units,
+      :short_ship_return_invoice_id,
+      unique: true,
+      name: 'index_spree_avatax_short_ships_on_invoice_id',
+    )
+  end
+end


### PR DESCRIPTION
Was previously set as unique, which was not correct -- A short ship
return invoice may have multiple units associated with it

Update specs to run with multiple units so this case is covered.