### PR TITLE
Use the line item's tax code for requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Known Issues
 ------------
 
 1. "Additional tax" (e.g. US taxes) *is* supported but "included tax" (e.g. VAT) is *not*.  This feature is not on the roadmap but we'd be willing to look at pull requests for it.
-2. Returns/Refunds/Exchanges are not currently being sent to Avatax.  This is on the todo list and will be worked during or soon after the returns & exchanges refactor that we're working on with Spree for Spree 2.4.
-3. Note for future development: There is currently a bug in Spree where the "open all adjustments" admin button doesn't work for line item adjustments. See [here](https://github.com/spree/spree/blob/v2.2.2/backend/app/controllers/spree/admin/orders_controller.rb#L103). If that bug were ever fixed, we'd want to monkey patch the controller action to prevent tax adjustments from ever being re-opened. We always want tax adjustments to be "closed", which tells Spree not to try to recalculate them automatically.
+2. Note for future development: There is currently a bug in Spree where the "open all adjustments" admin button doesn't work for line item adjustments. See [here](https://github.com/spree/spree/blob/v2.2.2/backend/app/controllers/spree/admin/orders_controller.rb#L103). If that bug were ever fixed, we'd want to monkey patch the controller action to prevent tax adjustments from ever being re-opened. We always want tax adjustments to be "closed", which tells Spree not to try to recalculate them automatically.
 
 Admin Configuration
 -------------------
 
-Once Avatax is configured, you should be able to select Avatax as a calculator for all tax rules. This can be done in the Spree Admin, http://localhost:3000/admin/tax_rates/ and editing each existing rule.
+1. Once Avatax is configured, you should be able to select Avatax as a calculator for all tax rules. This can be done in the Spree Admin, http://localhost:3000/admin/tax_rates/ and editing each existing rule.
+2. Tax categories should be setup in spree with the tax 'code' related to the Avalara tax codes since these are sent up with each line item in the requests.
 
 Testing
 -------

--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -157,6 +157,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
           # Required Parameters
           no:                  return_item.id,
           itemcode:            return_item.inventory_unit.line_item.variant.sku,
+          taxcode:             return_item.inventory_unit.line_item.tax_category.code,
           qty:                 1,
           amount:              -return_item.pre_tax_amount,
           origincodeline:      DESTINATION_CODE, # We don't really send the correct value here

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -194,6 +194,7 @@ module SpreeAvatax::SalesShared
 
           # Optional Parameters
           itemcode:   line_item.variant.sku,
+          taxcode:    line_item.tax_category.code,
           # "discounted" tells avatax to include this item when it distributes order-level discounts
           # across avatax "lines"
           discounted: true,

--- a/app/models/spree_avatax/short_ship_return_invoice.rb
+++ b/app/models/spree_avatax/short_ship_return_invoice.rb
@@ -111,6 +111,7 @@ class SpreeAvatax::ShortShipReturnInvoice < ActiveRecord::Base
           # Required Parameters
           no:                  inventory_unit.id,
           itemcode:            inventory_unit.line_item.variant.sku,
+          taxcode:             inventory_unit.line_item.tax_category.code,
           qty:                 1,
           amount:              -before_tax,
           origincodeline:      DESTINATION_CODE, # We don't really send the correct value here

--- a/spec/models/spree_avatax/return_invoice_spec.rb
+++ b/spec/models/spree_avatax/return_invoice_spec.rb
@@ -36,6 +36,7 @@ describe SpreeAvatax::ReturnInvoice do
           {
             no:                  return_item.id,
             itemcode:            return_item.inventory_unit.line_item.variant.sku,
+            taxcode:             return_item.inventory_unit.line_item.tax_category.code,
             qty:                 1,
             amount:              -return_item.pre_tax_amount,
             origincodeline:      SpreeAvatax::ReturnInvoice::DESTINATION_CODE,

--- a/spec/models/spree_avatax/sales_invoice_spec.rb
+++ b/spec/models/spree_avatax/sales_invoice_spec.rb
@@ -60,6 +60,7 @@ describe SpreeAvatax::SalesInvoice do
             description: expected_truncated_description,
 
             itemcode:   line_item.variant.sku,
+            taxcode:    line_item.tax_category.code,
             discounted: true,
           },
           { # shipping charge

--- a/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
+++ b/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
@@ -84,6 +84,7 @@ describe SpreeAvatax::ShortShipReturnInvoice do
             {
               no:                  inventory_unit_1.id,
               itemcode:            inventory_unit_1.line_item.variant.sku,
+              taxcode:             inventory_unit_1.line_item.tax_category.code,
               qty:                 1,
               amount:              -10.to_d,
               origincodeline:      SpreeAvatax::ShortShipReturnInvoice::DESTINATION_CODE,
@@ -99,6 +100,7 @@ describe SpreeAvatax::ShortShipReturnInvoice do
             {
               no:                  inventory_unit_2.id,
               itemcode:            inventory_unit_2.line_item.variant.sku,
+              taxcode:             inventory_unit_2.line_item.tax_category.code,
               qty:                 1,
               amount:              -10.to_d,
               origincodeline:      SpreeAvatax::ShortShipReturnInvoice::DESTINATION_CODE,

--- a/spree_avatax.gemspec
+++ b/spree_avatax.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax'
-  s.version     = '2.2.2'
+  s.version     = '2.2.3'
   s.summary     = 'Avatax extension for Spree 2.2.x'
   s.description = "Spree 2.2.x extension to retrieve tax rates via Avalara's SOAP API."
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
So that tax codes can be configured in Spree as opposed to in avalara
console.

depends on https://github.com/bonobos/spree/pull/395