### PR TITLE
Upgrade Avatax_TaxService dependency to allow verification with SSL certificate change.

### DIFF
--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -189,7 +189,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
       @tax_svc ||= AvaTax::TaxService.new({
         username:               SpreeAvatax::Config.username,
         password:               SpreeAvatax::Config.password,
-        use_production_account: SpreeAvatax::Config.use_production_account,
+        service_url:            SpreeAvatax::Config.service_url,
         clientname:             'Spree::Avatax',
       })
     end

--- a/app/models/spree_avatax/shared.rb
+++ b/app/models/spree_avatax/shared.rb
@@ -32,7 +32,7 @@ module SpreeAvatax::Shared
       @tax_svc ||= AvaTax::TaxService.new({
         username:               SpreeAvatax::Config.username,
         password:               SpreeAvatax::Config.password,
-        use_production_account: SpreeAvatax::Config.use_production_account,
+        service_url:            SpreeAvatax::Config.service_url,
         clientname:             'Spree::Avatax',
       })
     end

--- a/lib/generators/spree_avatax/install/templates/config/initializers/avatax.rb
+++ b/lib/generators/spree_avatax/install/templates/config/initializers/avatax.rb
@@ -2,7 +2,11 @@
 SpreeAvatax::Config.username = 'your avatax username'
 SpreeAvatax::Config.password = 'your avatax password'
 SpreeAvatax::Config.company_code = 'your avatax company code'
-SpreeAvatax::Config.use_production_account = Rails.env.production?
+if Rails.env.production?
+  SpreeAvatax::Config.service_url = "https://avatax.avalara.net"
+else
+  SpreeAvatax::Config.service_url = "https://development.avalara.net"
+end
 
 # Use Avatax to compute return invoice tax amounts
 Spree::Reimbursement.reimbursement_tax_calculator = lambda do |reimbursement|

--- a/lib/spree_avatax/config.rb
+++ b/lib/spree_avatax/config.rb
@@ -4,7 +4,7 @@ module SpreeAvatax
       attr_accessor :username
       attr_accessor :password
       attr_accessor :company_code
-      attr_accessor :use_production_account
+      attr_accessor :service_url
       # These error handlers should be objects that respond to "call" and accept an order and an
       # exception as arguments.  This allows you to ignore certain errors or handle them in
       # specific ways.
@@ -12,7 +12,5 @@ module SpreeAvatax
       attr_accessor :sales_invoice_commit_error_handler
       attr_accessor :sales_invoice_cancel_error_handler
     end
-
-    self.use_production_account = false
   end
 end

--- a/lib/tasks/commit_backfill.rake
+++ b/lib/tasks/commit_backfill.rake
@@ -32,7 +32,7 @@ namespace :spree_avatax do
     tax_svc = AvaTax::TaxService.new({
       username:               SpreeAvatax::Config.username,
       password:               SpreeAvatax::Config.password,
-      use_production_account: SpreeAvatax::Config.use_production_account,
+      service_url:            SpreeAvatax::Config.service_url,
       clientname:             'Spree::Avatax',
     })
 

--- a/spec/avalara_config.yml.example
+++ b/spec/avalara_config.yml.example
@@ -1,2 +1,3 @@
 username: 'YOUR ACCOUNT ID'
 password: 'YOUR PASSWORD'
+service_url: "https://development.avalara.net"

--- a/spec/features/tax_calculation_spec.rb
+++ b/spec/features/tax_calculation_spec.rb
@@ -78,7 +78,7 @@ describe "Tax Calculation" do
     @avalara_config = YAML.load_file("spec/avalara_config.yml")
     SpreeAvatax::Config.password = @avalara_config['password']
     SpreeAvatax::Config.username = @avalara_config['username']
-    SpreeAvatax::Config.use_production_account = false
+    SpreeAvatax::Config.service_url = @avalara_config['service_url']
     SpreeAvatax::Config.company_code = 'Bonobos'
   rescue => e
     skip("PLEASE PROVIDE AVALARA CONFIGURATIONS TO RUN LIVE TESTS [#{e.to_s}]")

--- a/spree_avatax.gemspec
+++ b/spree_avatax.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core',  '~> 2.2.2'
   s.add_dependency 'hashie',      '~> 2.l.5'
   s.add_dependency 'multi_json'
-  s.add_dependency 'Avatax_TaxService', '~> 1.0.14'
+  s.add_dependency 'Avatax_TaxService', '~> 2.0.0'
   s.add_dependency 'newrelic_rpm', '~> 3.11'
 
   s.add_development_dependency 'rails',   '~>4.0.3'


### PR DESCRIPTION
Per https://help.avalara.com/kb/001/AvaTax_Certificate_Change_July_2015
Avalara is swapping out its SSL certificate. They have released an
update to allow the endpoint url to be specified for testing:
https://github.com/avadev/AvaTax-SOAP-Ruby-SDK/issues/1#event-329955708.